### PR TITLE
gmscompat: update BluetoothAdapter.enable() shim for Android 13

### DIFF
--- a/framework/java/android/bluetooth/BluetoothAdapter.java
+++ b/framework/java/android/bluetooth/BluetoothAdapter.java
@@ -1246,9 +1246,8 @@ public final class BluetoothAdapter {
         }
 
         if (GmsCompat.isEnabled()) {
-            if (!GmsModuleHooks.canEnableBluetoothAdapter()) {
-                return false;
-            }
+            GmsModuleHooks.enableBluetoothAdapter();
+            return false;
         }
 
         try {
@@ -1458,9 +1457,8 @@ public final class BluetoothAdapter {
         }
 
         if (GmsCompat.isEnabled()) {
-            if (!GmsModuleHooks.canEnableBluetoothAdapter()) {
-                return false;
-            }
+            GmsModuleHooks.enableBluetoothAdapter();
+            return false;
         }
 
         try {


### PR DESCRIPTION
Android 13 doesn't allow unprivileged apps to silently enable Bluetooth.