### PR TITLE
gmscompat: return success instead of failure in BluetoothAdapter stubs

### DIFF
--- a/framework/java/android/bluetooth/BluetoothAdapter.java
+++ b/framework/java/android/bluetooth/BluetoothAdapter.java
@@ -1247,7 +1247,7 @@ public final class BluetoothAdapter {
 
         if (GmsCompat.isEnabled()) {
             GmsModuleHooks.enableBluetoothAdapter();
-            return false;
+            return true;
         }
 
         try {
@@ -1458,7 +1458,7 @@ public final class BluetoothAdapter {
 
         if (GmsCompat.isEnabled()) {
             GmsModuleHooks.enableBluetoothAdapter();
-            return false;
+            return true;
         }
 
         try {
@@ -1995,7 +1995,7 @@ public final class BluetoothAdapter {
             if (mode != SCAN_MODE_NONE) {
                 GmsModuleHooks.makeBluetoothAdapterDiscoverable();
             }
-            return BluetoothStatusCodes.ERROR_UNKNOWN;
+            return BluetoothStatusCodes.SUCCESS;
         }
 
         try {


### PR DESCRIPTION
This is needed to fix Nearby Share support in recent GmsCore versions.