### PR TITLE
gmscompat: add stub for AdvertisingSetParameters.setOwnAddressType(), ignore GattServer in BTLeAdvertiser.startAdvertisingSet

### DIFF
--- a/framework/java/android/bluetooth/le/AdvertisingSetParameters.java
+++ b/framework/java/android/bluetooth/le/AdvertisingSetParameters.java
@@ -19,6 +19,7 @@ package android.bluetooth.le;
 import android.annotation.IntDef;
 import android.annotation.NonNull;
 import android.annotation.SystemApi;
+import android.app.compat.gms.GmsCompat;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.os.Parcel;
@@ -477,6 +478,14 @@ public final class AdvertisingSetParameters implements Parcelable {
                             > AdvertisingSetParameters.ADDRESS_TYPE_RANDOM_NON_RESOLVABLE) {
                 throw new IllegalArgumentException("unknown address type " + ownAddressType);
             }
+
+            if (GmsCompat.isEnabled()) {
+                if (!GmsCompat.hasPermission(android.Manifest.permission.BLUETOOTH_PRIVILEGED)) {
+                    android.util.Log.d("GmsCompat", "skipped setOwnAddressType(" + ownAddressType + ")", new Throwable());
+                    return this;
+                }
+            }
+
             mOwnAddressType = ownAddressType;
             return this;
         }

--- a/framework/java/android/bluetooth/le/BluetoothLeAdvertiser.java
+++ b/framework/java/android/bluetooth/le/BluetoothLeAdvertiser.java
@@ -22,6 +22,7 @@ import android.annotation.RequiresNoPermission;
 import android.annotation.RequiresPermission;
 import android.annotation.SuppressLint;
 import android.annotation.SystemApi;
+import android.app.compat.gms.GmsCompat;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattServer;
@@ -500,6 +501,13 @@ public final class BluetoothLeAdvertiser {
         BluetoothLeUtils.checkAdapterStateOn(mBluetoothAdapter);
         if (callback == null) {
             throw new IllegalArgumentException("callback cannot be null");
+        }
+
+        if (GmsCompat.isEnabled()) {
+            if (gattServer != null && !GmsCompat.hasPermission(android.Manifest.permission.BLUETOOTH_PRIVILEGED)) {
+                Log.d("GmsCompat", "ignored BluetoothGattServer", new Throwable());
+                gattServer = null;
+            }
         }
 
         boolean isConnectable = parameters.isConnectable();


### PR DESCRIPTION
These adjustments are needed for receiving files through Quick Share on modern GmsCore versions.