### PR TITLE
gmscompat: replace GmsCompatConfig stubs with in-place checks

### DIFF
--- a/framework/java/android/bluetooth/BluetoothAdapter.java
+++ b/framework/java/android/bluetooth/BluetoothAdapter.java
@@ -4732,6 +4732,8 @@ public final class BluetoothAdapter {
                     mBluetoothConnectionCallback, mAttributionSource);
         } catch (RemoteException e) {
             Log.e(TAG, e.toString() + "\n" + Log.getStackTraceString(new Throwable()));
+        } catch (SecurityException se) {
+            GmsCompat.catchOrRethrow(se);
         } finally {
             mServiceLock.readLock().unlock();
         }
@@ -4785,6 +4787,8 @@ public final class BluetoothAdapter {
                             mBluetoothConnectionCallback, mAttributionSource);
                 } catch (RemoteException e) {
                     Log.e(TAG, e.toString() + "\n" + Log.getStackTraceString(new Throwable()));
+                } catch (SecurityException se) {
+                    GmsCompat.catchOrRethrow(se);
                 } finally {
                     mServiceLock.readLock().unlock();
                 }

--- a/framework/java/android/bluetooth/BluetoothDevice.java
+++ b/framework/java/android/bluetooth/BluetoothDevice.java
@@ -28,6 +28,7 @@ import android.annotation.SdkConstant.SdkConstantType;
 import android.annotation.SuppressLint;
 import android.annotation.SystemApi;
 import android.app.compat.CompatChanges;
+import android.app.compat.gms.GmsCompat;
 import android.bluetooth.annotations.RequiresBluetoothConnectPermission;
 import android.bluetooth.annotations.RequiresBluetoothLocationPermission;
 import android.bluetooth.annotations.RequiresBluetoothScanPermission;
@@ -1662,6 +1663,9 @@ public final class BluetoothDevice implements Parcelable, Attributable {
                 return service.getIdentityAddress(mAddress);
             } catch (RemoteException e) {
                 Log.e(TAG, e.toString() + "\n" + Log.getStackTraceString(new Throwable()));
+            } catch (SecurityException se) {
+                GmsCompat.catchOrRethrow(se);
+                return null;
             }
         }
         return null;
@@ -2576,6 +2580,8 @@ public final class BluetoothDevice implements Parcelable, Attributable {
                 return service.setPairingConfirmation(this, confirm, mAttributionSource);
             } catch (RemoteException e) {
                 Log.e(TAG, e.toString() + "\n" + Log.getStackTraceString(new Throwable()));
+            } catch (SecurityException se) {
+                GmsCompat.catchOrRethrow(se);
             }
         }
         return false;
@@ -2652,6 +2658,8 @@ public final class BluetoothDevice implements Parcelable, Attributable {
                 return service.setSilenceMode(this, silence, mAttributionSource);
             } catch (RemoteException e) {
                 Log.e(TAG, e.toString() + "\n" + Log.getStackTraceString(new Throwable()));
+            } catch (SecurityException se) {
+                GmsCompat.catchOrRethrow(se);
             }
         }
         return false;
@@ -3341,6 +3349,8 @@ public final class BluetoothDevice implements Parcelable, Attributable {
                 return service.setMetadata(this, key, value, mAttributionSource);
             } catch (RemoteException e) {
                 Log.e(TAG, e.toString() + "\n" + Log.getStackTraceString(new Throwable()));
+            } catch (SecurityException se) {
+                GmsCompat.catchOrRethrow(se);
             }
         }
         return false;
@@ -3371,6 +3381,8 @@ public final class BluetoothDevice implements Parcelable, Attributable {
                 return service.getMetadata(this, key, mAttributionSource);
             } catch (RemoteException e) {
                 Log.e(TAG, e.toString() + "\n" + Log.getStackTraceString(new Throwable()));
+            } catch (SecurityException se) {
+                GmsCompat.catchOrRethrow(se);
             }
         }
         return null;

--- a/framework/java/android/bluetooth/BluetoothGattServer.java
+++ b/framework/java/android/bluetooth/BluetoothGattServer.java
@@ -21,6 +21,7 @@ import android.annotation.NonNull;
 import android.annotation.RequiresNoPermission;
 import android.annotation.RequiresPermission;
 import android.annotation.SuppressLint;
+import android.app.compat.gms.GmsCompat;
 import android.bluetooth.annotations.RequiresBluetoothConnectPermission;
 import android.bluetooth.annotations.RequiresLegacyBluetoothPermission;
 import android.content.AttributionSource;
@@ -643,6 +644,9 @@ public final class BluetoothGattServer implements BluetoothProfile {
             } catch (RemoteException e) {
                 Log.e(TAG, "", e);
                 mCallback = null;
+                return false;
+            } catch (SecurityException se) {
+                GmsCompat.catchOrRethrow(se);
                 return false;
             }
 

--- a/framework/java/android/bluetooth/le/BluetoothLeAdvertiser.java
+++ b/framework/java/android/bluetooth/le/BluetoothLeAdvertiser.java
@@ -605,7 +605,7 @@ public final class BluetoothLeAdvertiser {
             return;
         } catch (SecurityException e) {
             mCallbackWrappers.remove(callback);
-            throw e;
+            GmsCompat.catchOrRethrow(e);
         }
     }
 


### PR DESCRIPTION
In-place checks are more reliable and more readable because of surrounding context.

Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/30