### PR TITLE
Backport regression fixes for 288144143

### DIFF
--- a/system/stack/btm/btm_ble_sec.cc
+++ b/system/stack/btm/btm_ble_sec.cc
@@ -1146,6 +1146,10 @@ tBTM_STATUS btm_ble_set_encryption(const RawAddress& bd_addr, tBTM_BLE_SEC_ACT s
   }
 
   switch (sec_act) {
+    if (p_rec->sec_rec.is_le_device_encrypted()) {
+      return tBTM_STATUS::BTM_SUCCESS;
+    }
+
     case BTM_BLE_SEC_ENCRYPT:
       if (link_role == HCI_ROLE_CENTRAL) {
         /* start link layer encryption using the security info stored */
@@ -1545,6 +1549,32 @@ void btm_ble_connected(const RawAddress& bda, uint16_t handle, uint8_t /* enc_mo
   btm_cb.ble_ctr_cb.inq_var.directed_conn = BTM_BLE_ADV_IND_EVT;
 }
 
+static bool btm_ble_complete_evt_ignore(const tBTM_SEC_DEV_REC* p_dev_rec,
+                                        const tSMP_EVT_DATA* p_data) {
+  // Encryption request in peripheral role results in SMP Security request. SMP may generate a
+  // SMP_COMPLT_EVT failure event cases like below:
+  // 1) Some central devices don't handle cross-over between encryption and SMP security request
+  // 2) Link may get disconnected after the SMP security request was sent.
+  if (p_data->cmplt.reason != SMP_SUCCESS && !p_dev_rec->role_central &&
+      btm_sec_cb.pairing_bda != p_dev_rec->bd_addr &&
+      btm_sec_cb.pairing_bda != p_dev_rec->ble.pseudo_addr &&
+      p_dev_rec->sec_rec.is_le_link_key_known() &&
+      p_dev_rec->sec_rec.ble_keys.key_type != BTM_LE_KEY_NONE) {
+    if (p_dev_rec->sec_rec.is_le_device_encrypted()) {
+      log::warn("Bonded device {} is already encrypted, ignoring SMP failure", p_dev_rec->bd_addr);
+      return true;
+    } else if (p_data->cmplt.reason == SMP_CONN_TOUT) {
+      log::warn("Bonded device {} disconnected while waiting for encryption, ignoring SMP failure",
+                p_dev_rec->bd_addr);
+      l2cu_start_post_bond_timer(p_dev_rec->ble_hci_handle);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
 /*******************************************************************************
  *
  * Function         btm_ble_connection_established
@@ -1739,7 +1769,9 @@ tBTM_STATUS btm_proc_smp_cback(tSMP_EVT event, const RawAddress& bd_addr, tSMP_E
       break;
 
     case SMP_COMPLT_EVT:
-      btm_ble_complete_evt(bd_addr, p_dev_rec, reinterpret_cast<tBTM_LE_EVT_DATA*>(p_data));
+      if (!btm_ble_complete_evt_ignore(p_dev_rec, p_data)) {
+        btm_ble_complete_evt(bd_addr, p_dev_rec, reinterpret_cast<tBTM_LE_EVT_DATA*>(p_data));
+      }
       break;
 
     case SMP_LE_ADDR_ASSOC_EVT:

--- a/system/stack/l2cap/l2c_ble.cc
+++ b/system/stack/l2cap/l2c_ble.cc
@@ -108,10 +108,10 @@ void l2cble_notify_le_connection(const RawAddress& bda) {
   if (get_btm_client_interface().peer.BTM_IsAclConnectionUp(bda, BT_TRANSPORT_LE) &&
       p_lcb->link_state != LST_CONNECTED) {
     /* update link status */
+    p_lcb->link_state = LST_CONNECTED;
     // TODO Move this back into acl layer
     btm_establish_continue_from_address(bda, BT_TRANSPORT_LE);
-    /* update l2cap link status and send callback */
-    p_lcb->link_state = LST_CONNECTED;
+    /* send callback */
     l2cu_process_fixed_chnl_resp(p_lcb);
   }
 


### PR DESCRIPTION
These are backports for the following AOSP changes: aosp/3424923
aosp/3420039
aosp/3394039

which address regressions in the initial fix for above bug.

Bug: 288144143
Test: m libbluetooth
Ignore-AOSP-First: security
Tag: #security
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:39a69ddf3bde00b572bd75f9b27e4acc736a2740) Merged-In: I877223e4a7141c73bc28ae2133fd26f4bd736321 Change-Id: I877223e4a7141c73bc28ae2133fd26f4bd736321