### PR TITLE
extend privileged Android Auto perm to A2dpService.getConnectionPolicy()

### DIFF
--- a/android/app/src/com/android/bluetooth/a2dp/A2dpServiceBinder.java
+++ b/android/app/src/com/android/bluetooth/a2dp/A2dpServiceBinder.java
@@ -179,7 +179,12 @@ class A2dpServiceBinder extends IBluetoothA2dp.Stub implements IProfileServiceBi
             return CONNECTION_POLICY_UNKNOWN;
         }
 
-        service.enforceCallingOrSelfPermission(BLUETOOTH_PRIVILEGED, null);
+        try {
+            service.enforceCallingOrSelfPermission(BLUETOOTH_PRIVILEGED, null);
+        } catch (SecurityException e) {
+            Utils.enforceBluetoothPrivilegedAndroidAutoOrThrow(service, e);
+        }
+
         return service.getConnectionPolicy(device);
     }
 


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7484

In general, Android Auto seems to maintain a A2DP proxy in order to disable and potentially re-enable A2DP.

For Android Auto's BluetoothProfile.ServiceListener for BluetoothProfile.A2DP, when onServiceConnected occurs, it now uses A2dpService.getConnectionPolicy() to store the previous connection policy before setting connection policy to CONNECTION_POLICY_FORBIDDEN. This previous policy is used to decide whether it needs to set it back to CONNECTION_POLICY_ALLOWED when closing the A2DP proxy. If it was already CONNECTION_POLICY_FORBIDDEN before the ServiceListener connected, then it won't set it to ALLOWED when closing the A2DP proxy.