### PR TITLE
Bluetooth: Add BLE(Bluetooth Low Energy) only mode [3/4]

### DIFF
--- a/android/app/src/com/android/bluetooth/btservice/BluetoothSocketManagerBinder.java
+++ b/android/app/src/com/android/bluetooth/btservice/BluetoothSocketManagerBinder.java
@@ -26,6 +26,7 @@ import android.content.AttributionSource;
 import android.os.Binder;
 import android.os.ParcelFileDescriptor;
 import android.os.ParcelUuid;
+import android.os.SystemProperties;
 import android.util.Log;
 
 import com.android.bluetooth.Utils;
@@ -36,6 +37,13 @@ class BluetoothSocketManagerBinder extends IBluetoothSocketManager.Stub {
     private static final int INVALID_FD = -1;
 
     private static final int INVALID_CID = -1;
+
+    private static final String BLE_ONLY_PROPERTY = "persist.bluetooth.ble_only";
+
+    private static boolean isBleOnlyBlockedSocket(int type) {
+        return type != BluetoothSocket.TYPE_LE
+                && SystemProperties.getBoolean(BLE_ONLY_PROPERTY, false);
+    }
 
     private AdapterService mService;
 
@@ -59,6 +67,16 @@ class BluetoothSocketManagerBinder extends IBluetoothSocketManager.Stub {
         enforceActiveUser();
 
         if (!Utils.checkConnectPermissionForPreflight(mService, source)) {
+            return null;
+        }
+
+        if (isBleOnlyBlockedSocket(type)) {
+            Log.w(
+                    TAG,
+                    "connectSocket: BLE-only mode, rejecting Classic socket type="
+                            + type
+                            + " from "
+                            + Utils.getUidPidString());
             return null;
         }
 
@@ -116,6 +134,16 @@ class BluetoothSocketManagerBinder extends IBluetoothSocketManager.Stub {
             return null;
         }
 
+        if (isBleOnlyBlockedSocket(type)) {
+            Log.w(
+                    TAG,
+                    "connectSocketWithOffload: BLE-only mode, rejecting Classic socket type="
+                            + type
+                            + " from "
+                            + Utils.getUidPidString());
+            return null;
+        }
+
         if (dataPath != BluetoothSocketSettings.DATA_PATH_NO_OFFLOAD) {
             mService.enforceCallingOrSelfPermission(BLUETOOTH_PRIVILEGED, null);
             enforceSocketOffloadSupport(type);
@@ -170,6 +198,16 @@ class BluetoothSocketManagerBinder extends IBluetoothSocketManager.Stub {
             return null;
         }
 
+        if (isBleOnlyBlockedSocket(type)) {
+            Log.w(
+                    TAG,
+                    "createSocketChannel: BLE-only mode, rejecting Classic socket type="
+                            + type
+                            + " from "
+                            + Utils.getUidPidString());
+            return null;
+        }
+
         Log.i(
                 TAG,
                 "createSocketChannel: type="
@@ -216,6 +254,16 @@ class BluetoothSocketManagerBinder extends IBluetoothSocketManager.Stub {
         enforceActiveUser();
 
         if (!Utils.checkConnectPermissionForPreflight(mService, source)) {
+            return null;
+        }
+
+        if (isBleOnlyBlockedSocket(type)) {
+            Log.w(
+                    TAG,
+                    "createSocketChannelWithOffload: BLE-only mode, rejecting Classic socket type="
+                            + type
+                            + " from "
+                            + Utils.getUidPidString());
             return null;
         }
 

--- a/android/app/src/com/android/bluetooth/btservice/Config.java
+++ b/android/app/src/com/android/bluetooth/btservice/Config.java
@@ -78,6 +78,34 @@ public class Config {
         }
     }
 
+    /**
+     * Profiles that operate purely over Bluetooth Classic (BR/EDR). These are disabled when the
+     * user enables the "BLE only" mode.
+     *
+     * <p>Note: HID_HOST is intentionally absent. HidHostService also serves LE HID (HOGP) over
+     * GATT, which must keep working in BLE-only mode, so the whole profile cannot be disabled.
+     * Its BR/EDR transport is instead blocked inside HidHostService when BLE-only is active.
+     * HID_DEVICE (the device/peripheral role) is BR/EDR-only and stays in this list.
+     */
+    private static final String BLE_ONLY_PROPERTY = "persist.bluetooth.ble_only";
+
+    private static final int[] CLASSIC_PROFILES = {
+        BluetoothProfile.A2DP,
+        BluetoothProfile.A2DP_SINK,
+        BluetoothProfile.AVRCP,
+        BluetoothProfile.AVRCP_CONTROLLER,
+        BluetoothProfile.HEADSET,
+        BluetoothProfile.HEADSET_CLIENT,
+        BluetoothProfile.HID_DEVICE,
+        BluetoothProfile.MAP,
+        BluetoothProfile.MAP_CLIENT,
+        BluetoothProfile.OPP,
+        BluetoothProfile.PAN,
+        BluetoothProfile.PBAP,
+        BluetoothProfile.PBAP_CLIENT,
+        BluetoothProfile.SAP,
+    };
+
     /** List of profile services related to LE audio */
     private static final int[] LE_AUDIO_UNICAST_PROFILES = {
         BluetoothProfile.LE_AUDIO,
@@ -210,6 +238,16 @@ public class Config {
         // accidentally
         if (!Utils.isBleSupported(ctx)) {
             setProfileEnabled(BluetoothProfile.HEARING_AID, false);
+        }
+
+        // GrapheneOS: when "BLE only" is enabled, disable all Classic (BR/EDR) profiles.
+        // The toggle's preference controller restarts the adapter on change so this
+        // init() runs again and re-reads the new value.
+        if (SystemProperties.getBoolean(BLE_ONLY_PROPERTY, false)) {
+            Log.i(TAG, "BLE-only mode enabled: disabling Classic profiles");
+            for (int p : CLASSIC_PROFILES) {
+                setProfileEnabled(p, false);
+            }
         }
 
         for (ProfileConfig config : PROFILE_SERVICES_AND_FLAGS) {

--- a/android/app/src/com/android/bluetooth/hid/HidHostService.java
+++ b/android/app/src/com/android/bluetooth/hid/HidHostService.java
@@ -40,6 +40,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.os.ParcelUuid;
+import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.sysprop.BluetoothProperties;
 import android.util.Log;
@@ -122,6 +123,14 @@ public class HidHostService extends ConnectableProfile {
     private static final int MESSAGE_SEND_DATA = 18;
 
     public static final int STATE_ACCEPTING = STATE_DISCONNECTING + 1;
+
+    // GrapheneOS: when this system property is true, only Bluetooth LE works. The HID host
+    // service stays enabled so LE HID (HOGP) over GATT keeps working, but BR/EDR HID is blocked.
+    private static final String BLE_ONLY_PROPERTY = "persist.bluetooth.ble_only";
+
+    private static boolean isBleOnly() {
+        return SystemProperties.getBoolean(BLE_ONLY_PROPERTY, false);
+    }
 
     public HidHostService(AdapterService adapterService) {
         this(adapterService, null);
@@ -518,6 +527,19 @@ public class HidHostService extends ConnectableProfile {
         int state = msg.arg2;
         int prevState = getState(device, transport);
 
+        // GrapheneOS: in BLE-only mode, tear down any BR/EDR HID link. LE HID (HOGP, reported
+        // with TRANSPORT_LE) is unaffected and keeps working.
+        if (transport == TRANSPORT_BREDR && state != STATE_DISCONNECTED && isBleOnly()) {
+            Log.i(
+                    TAG,
+                    "handleMessageConnectStateChanged: BLE-only mode, blocking BR/EDR HID"
+                            + (" device=" + device)
+                            + (" state=" + state));
+            nativeDisconnect(device, TRANSPORT_BREDR, false);
+            updateConnectionState(device, TRANSPORT_BREDR, STATE_DISCONNECTED);
+            return;
+        }
+
         InputDevice inputDevice = mInputDevices.get(device);
         if (inputDevice != null) {
             // Update transport if it was not resolved already
@@ -596,6 +618,13 @@ public class HidHostService extends ConnectableProfile {
                             + (" device=" + device)
                             + (" connectionPolicy=" + connectionPolicy));
 
+            return;
+        }
+        // GrapheneOS: in BLE-only mode, don't initiate a BR/EDR HID connection. AUTO/LE are
+        // left alone so LE HID (HOGP) still connects; any BR/EDR link that the native stack
+        // resolves from AUTO is torn down in handleMessageConnectStateChanged.
+        if (inputDevice.mSelectedTransport == TRANSPORT_BREDR && isBleOnly()) {
+            Log.i(TAG, "handleMessageConnect: BLE-only mode, skipping BR/EDR HID device=" + device);
             return;
         }
         nativeConnect(device, inputDevice.mSelectedTransport);


### PR DESCRIPTION
This pull request adds support for a new "BLE only" (Bluetooth Low Energy only) mode in the Bluetooth settings. This feature allows users to restrict Bluetooth functionality to BLE mode for improved security, at the cost of reduced compatibility. 
Part of https://github.com/GrapheneOS/os-issue-tracker/issues/7096